### PR TITLE
Reload im Report Container.

### DIFF
--- a/WeBBAKI/src/main/resources/templates/report/report_container.html
+++ b/WeBBAKI/src/main/resources/templates/report/report_container.html
@@ -13,7 +13,7 @@
         <div layout:fragment="content">
             <div class="container">
                 <h4 id="snapshotH5">Der Report von:</h4>
-                <select id="snapshotSelect" onchange="onThreatSituationChange(this)" class="form-select form-select-sm">
+                <select id="snapshotSelect" onchange="onChange(this)" class="form-select form-select-sm">
                     <option th:each="snapshot, iStat : ${snapshotList}" th:text="${snapshot.getName()}" th:value="${snapshot.getId()}" th:selected='${((currentSnapshot.getId() == snapshot.getId())?("true"):("false"))}'></option>
                 </select>
                 <th:block th:if="${report.getNumberOfQuestionnaires() > 0}">


### PR DESCRIPTION
Reload ist jetzt möglich. Scheinbar wurde nur ausversehen die falsche Methode aufgerufen. (Die Methode zum manipulieren der aktuallen URL war nämlich schon da (siehe Änderung).